### PR TITLE
Apply version spec change

### DIFF
--- a/quilt.mod.json/schemas/schema_version_1.json
+++ b/quilt.mod.json/schemas/schema_version_1.json
@@ -186,7 +186,7 @@
               }
             }
           },
-          "required": "any",
+          "required": ["any"],
           "not": { "required": [ "all" ] }
         },
         {
@@ -198,7 +198,7 @@
               }
             }
           },
-          "required": "all",
+          "required": ["all"],
           "not": { "required": [ "any" ] }
         }
       ]

--- a/quilt.mod.json/schemas/schema_version_1.json
+++ b/quilt.mod.json/schemas/schema_version_1.json
@@ -129,6 +129,9 @@
                       "items": {
                         "$ref": "#/$defs/version_specifier"
                       }
+                    },
+                    {
+                      "$ref": "#/$defs/dependency_version_object"
                     }
                   ],
                   "default": "*"
@@ -165,6 +168,46 @@
         },
         {
           "$ref": "#/$defs/dependency_object_array"
+        }
+      ]
+    },
+    "dependency_version_object": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/dependency_version"
+              }
+            }
+          },
+          "required": "any",
+          "not": { "required": [ "all" ] }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/dependency_version"
+              }
+            }
+          },
+          "required": "all",
+          "not": { "required": [ "any" ] }
+        }
+      ]
+    },
+    "dependency_version": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/version_specifier"
+        },
+        {
+          "$ref": "#/$defs/dependency_version_object"
         }
       ]
     },

--- a/quilt.mod.json/schemas/schema_version_1.json
+++ b/quilt.mod.json/schemas/schema_version_1.json
@@ -119,7 +119,7 @@
                 },
                 "versions": {
                   "title": "The versions field",
-                  "description": "Should be a version specifier or array of version specifiers defining what versions this dependency applies to. If an array of versions is provided, the dependency matches if it matches ANY of the listed versions.",
+                  "description": "Should be a version specifier or object defining what versions this dependency applies to.",
                   "oneOf": [
                     {
                       "$ref": "#/$defs/version_specifier"
@@ -172,9 +172,12 @@
       ]
     },
     "dependency_version_object": {
+      "title": "A dependency version object",
+      "description": "Describes a version of the dependency. Can either contain the property all, or the property any. Both properties take an array as a value, which itself can contain another version object or a version string.",
+      "markdownDescription": "Describes a version of the dependency. Can either contain the property `all`, or the property `any`. Both properties take an array as a value, which itself can contain another version object or a version string.",
+      "type": "object",
       "oneOf": [
         {
-          "type": "object",
           "properties": {
             "any": {
               "type": "array",
@@ -187,7 +190,6 @@
           "not": { "required": [ "all" ] }
         },
         {
-          "type": "object",
           "properties": {
             "all": {
               "type": "array",


### PR DESCRIPTION
This PR adds the new version format outlined in [RFC 56](https://github.com/QuiltMC/rfcs/pull/56).
While the old array-style version declaration is still accepted at a top level, I removed it from the description. Additionally, it isnt accepted inside the new dependency objects.